### PR TITLE
build: disabled incremental compilation

### DIFF
--- a/.changeset/cuddly-trees-invent.md
+++ b/.changeset/cuddly-trees-invent.md
@@ -1,0 +1,5 @@
+---
+"@nikolovlazar/chakra-ui-prose": patch
+---
+
+avoid shipping tsbuildinfo files

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ dist
 # TernJS port file
 .tern-port
 .turbo
+
+**/*.DS_Store

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "downlevelIteration": true,
-    "incremental": true,
+    "incremental": false,
     "declarationMap": true,
     "outDir": "./dist"
   },


### PR DESCRIPTION
Closes #7 

Currently the TypeScript compilation is configured as incremental. That generated a `tsconfig.tsbuildinfo` file which produced a super heavy package (100kB+). I could've added it to `.npmignore`, but I decided to turn off the incremental compilation completely. The whole source is less than 250 LoC anyway.